### PR TITLE
Filtering options for username and messages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -25,7 +25,7 @@ h2,
 h3 {
   color: #a78bfa;
   margin-top: 0;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 ol {
@@ -62,29 +62,6 @@ code {
   overflow-wrap: break-word;
 }
 
-.url-container {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-direction: column;
-  padding: 1rem;
-  border: 1px solid #444;
-  border-radius: 6px;
-  margin-top: 1rem;
-  gap: 1rem;
-  background: #1e1e1e;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-}
-
-.logged-in-info-box {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-  background: #232326;
-  margin-bottom: 1rem;
-  justify-content: center;
-}
-
 .error {
   color: #ff4d4d;
   background-color: #330000;
@@ -104,6 +81,7 @@ code {
 details[open] summary ~ section {
   animation: sweep 0.3s ease-in-out;
   padding: 1rem;
+  margin: 1rem;
   border: 1px solid #323133;
   border-radius: 5px;
   margin-top: 0.5rem;
@@ -128,13 +106,6 @@ footer {
   padding: 1rem;
   font-size: 0.875rem;
   color: #888;
-}
-
-.not-logged-in {
-  border-radius: 5px;
-  padding: 1rem;
-  text-align: center;
-  margin-bottom: 1rem;
 }
 
 .button-update-chat {

--- a/src/TwitchAuthHandler.tsx
+++ b/src/TwitchAuthHandler.tsx
@@ -1,5 +1,6 @@
 import { Redirect } from 'wouter';
 import { persistedStore } from './store/store';
+import { logger } from './utils/logger';
 
 const getTwitchAuthResponseData = () => {
   const url = new URL(window.location.href);
@@ -18,7 +19,7 @@ export const TwitchAuthHandler = () => {
   const { accessToken, state } = getTwitchAuthResponseData();
 
   if (state !== authStateValue) {
-    console.error('Invalid state value. Possible CSRF attack. Expected:', authStateValue, 'Received:', state);
+    logger.error('Invalid state value. Possible CSRF attack. Expected:', authStateValue, 'Received:', state);
     return <span>Error: Invalid state value.</span>;
   }
 

--- a/src/TwitchBroadcasterIdLoader.tsx
+++ b/src/TwitchBroadcasterIdLoader.tsx
@@ -5,6 +5,7 @@ import { validateAccessToken } from './handlers/twitch/id/validateAccessToken';
 import { useMount } from './hooks/useMount';
 import { loadEmotes } from './loadEmotes';
 import { persistedStore, store } from './store/store';
+import { logger } from './utils/logger';
 
 async function getBroadcasterIdFromAccessToken(): Promise<{ id: string; login: string } | null> {
   const result = await validateAccessToken();
@@ -44,7 +45,7 @@ export const TwitchBroadcasterIdLoader = () => {
       // If a channel is specified, try to get the broadcaster ID from the channel name
       if (channel) {
         loadedBroadcasterId = await getBroadcasterIdFromChannel(channel);
-        console.log('Loaded broadcaster ID:', loadedBroadcasterId, 'from channel:', channel);
+        logger.info('Loaded broadcaster ID:', loadedBroadcasterId, 'from channel:', channel);
       }
 
       // If we still don't have a broadcaster ID, try to get it from the access token,
@@ -52,13 +53,13 @@ export const TwitchBroadcasterIdLoader = () => {
       if (!loadedBroadcasterId || !userId || !userLogin) {
         const res = await getBroadcasterIdFromAccessToken();
         if (!res) {
-          console.error('Failed to get broadcaster ID from access token');
+          logger.error('Failed to get broadcaster ID from access token');
           return;
         }
         if (res.id && res.login) {
-          console.log('Loaded broadcaster ID:', res.id, 'from access token');
+          logger.info('Loaded broadcaster ID:', res.id, 'from access token');
           loadedBroadcasterId ??= res.id;
-          console.log('Loaded user ID:', res.id, 'from access token');
+          logger.info('Loaded user ID:', res.id, 'from access token');
           store.getState().setUserId(res.id);
           store.getState().setUserLogin(res.login);
         }

--- a/src/TwitchWebSocketClient.tsx
+++ b/src/TwitchWebSocketClient.tsx
@@ -6,6 +6,7 @@ import { twitchEventSubHandler } from './handlers/twitch/twitchEventSubHandler';
 import { store } from './store/store';
 import { EventsubEvent, EventSubResponse } from './types/twitchEvents';
 import { hasOwnProperty } from './utils/hasOwnProperty';
+import { logger } from './utils/logger';
 
 export const TwitchWebSocketClient = () => {
   const broadcasterId = store((s) => s.broadcasterId);
@@ -21,7 +22,7 @@ export const TwitchWebSocketClient = () => {
     const data = lastMessage?.data;
 
     if (!data) {
-      console.warn('No data received in last message');
+      logger.warn('No data received in last message');
       return;
     }
     const jsonData = JSON.parse(data);

--- a/src/components/ColorPicker/ColorPicker.less
+++ b/src/components/ColorPicker/ColorPicker.less
@@ -5,4 +5,10 @@
   gap: 1rem;
   border: 1px solid #433b5d;
   padding: 1rem;
+  border-radius: 5px;
+
+  &-footer {
+    display: flex;
+    gap: 1rem;
+  }
 }

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -8,9 +8,10 @@ interface ColorPickerProps {
   value: string;
   placeholder: string;
   setToDefault: () => void;
+  canSetToTransparent?: boolean;
 }
 
-export const ColorPicker = ({ id, onChange, value, placeholder, setToDefault }: ColorPickerProps) => {
+export const ColorPicker = ({ id, onChange, value, placeholder, setToDefault, canSetToTransparent = false }: ColorPickerProps) => {
   return (
     <div className="color-picker">
       <label htmlFor={id}>{value}</label>
@@ -22,9 +23,16 @@ export const ColorPicker = ({ id, onChange, value, placeholder, setToDefault }: 
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
       />
-      <Button type="secondary" onClick={setToDefault}>
-        Reset to default
-      </Button>
+      <div className="color-picker-footer">
+        <Button type="secondary" onClick={setToDefault}>
+          Reset to default
+        </Button>
+        {canSetToTransparent && (
+          <Button type="secondary" onClick={() => onChange('transparent')}>
+            Set to transparent
+          </Button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Button } from '../../components/Button/Button';
+import { Button } from '../Button/Button';
 
 const backdropStyle: React.CSSProperties = {
   position: 'fixed',

--- a/src/components/FilterEditor/FilterEditor.less
+++ b/src/components/FilterEditor/FilterEditor.less
@@ -1,0 +1,9 @@
+.filter-editor {
+  &-rules {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+    flex-direction: column;
+  }
+}

--- a/src/components/FilterEditor/FilterEditor.tsx
+++ b/src/components/FilterEditor/FilterEditor.tsx
@@ -1,0 +1,91 @@
+import {} from 'react';
+import type { UserFilterConfig, UserFilterRule } from '../../utils/filters';
+import { Button } from '../Button/Button';
+import { Space } from '../Space/Space';
+
+import './FilterEditor.less';
+
+type FilterEditorProps = {
+  value: UserFilterConfig;
+  onChange: (cfg: UserFilterConfig) => void;
+};
+
+const matchTypes: UserFilterRule['matchType'][] = ['exact', 'contains', 'wildcard'];
+
+export function FilterEditor({ value, onChange }: FilterEditorProps) {
+  const rules = value.rules ?? [];
+  const hasRules = (rules?.length ?? 0) > 0;
+
+  const addRule = () => {
+    const next: UserFilterRule = { matchType: 'exact', pattern: '', caseSensitive: false };
+    onChange({ rules: [...rules, next] });
+  };
+
+  const updateRule = (idx: number, patch: Partial<UserFilterRule>) => {
+    const next = [...rules];
+    next[idx] = { ...next[idx], ...patch } as UserFilterRule;
+    onChange({ rules: next });
+  };
+
+  const removeRule = (idx: number) => {
+    const next = rules.filter((_, i) => i !== idx);
+    onChange({ rules: next });
+  };
+
+  const clearAll = () => onChange({ rules: [] });
+
+  return (
+    <div className="filter-editor">
+      <p className="info">
+        Username filter rules (optional). Exclude usernames by exact, contains, or wildcard (* and ?). Case-insensitive by default.
+      </p>
+      {hasRules ? (
+        <div className="filter-editor-rules">
+          {rules.map((r, idx) => (
+            <div
+              className="filter-editor-rule"
+              key={idx}
+              style={{ display: 'grid', gridTemplateColumns: 'repeat(4, auto)', gap: 8, alignItems: 'center' }}
+            >
+              <select value={r.matchType} onChange={(e) => updateRule(idx, { matchType: e.target.value as UserFilterRule['matchType'] })}>
+                {matchTypes.map((mt) => (
+                  <option key={mt} value={mt}>
+                    {mt}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="text"
+                placeholder="pattern"
+                value={r.pattern}
+                onChange={(e) => updateRule(idx, { pattern: e.target.value })}
+                autoComplete="off"
+              />
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                <input type="checkbox" checked={!!r.caseSensitive} onChange={(e) => updateRule(idx, { caseSensitive: e.target.checked })} />
+                Case sensitive
+              </label>
+              <Button type="secondary" onClick={() => removeRule(idx)}>
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>No filters defined.</p>
+      )}
+      <Space>
+        <Button type="secondary" onClick={addRule}>
+          Add rule
+        </Button>
+        {hasRules && (
+          <Button type="secondary" onClick={clearAll}>
+            Clear all
+          </Button>
+        )}
+      </Space>
+    </div>
+  );
+}
+
+export default FilterEditor;

--- a/src/components/FilterEditor/FilterEditor.tsx
+++ b/src/components/FilterEditor/FilterEditor.tsx
@@ -36,9 +36,6 @@ export function FilterEditor({ value, onChange }: FilterEditorProps) {
 
   return (
     <div className="filter-editor">
-      <p className="info">
-        Username filter rules (optional). Exclude usernames by exact, contains, or wildcard (* and ?). Case-insensitive by default.
-      </p>
       {hasRules ? (
         <div className="filter-editor-rules">
           {rules.map((r, idx) => (

--- a/src/components/Space/Space.tsx
+++ b/src/components/Space/Space.tsx
@@ -1,3 +1,3 @@
 export const Space = ({ children }: { children: React.ReactNode }) => {
-  return <div style={{ display: 'flex', gap: '1rem', marginBottom: '1rem' }}>{children}</div>;
+  return <div style={{ display: 'flex', gap: '1rem' }}>{children}</div>;
 };

--- a/src/components/TextStrokePicker/TextStrokeEditor.tsx
+++ b/src/components/TextStrokePicker/TextStrokeEditor.tsx
@@ -31,7 +31,6 @@ const Segmented = styled.div`
   background: #1f1f1f;
   border: 1px solid #3a3a3a;
   border-radius: 6px;
-  overflow: hidden;
 
   button {
     background: transparent;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const DEFAULT_CHAT_SETTINGS_VALUES = {
   textStrokeSettings: PRESET_CHAT_SETTINGS_VALUES.textStrokeSettingsPresetThin,
   fontSizeValue: PRESET_CHAT_SETTINGS_VALUES.fontSizeValueMedium,
   fontSizeUnit: PRESET_CHAT_SETTINGS_VALUES.fontSizeUnit,
-  fontFamily: 'Sans-Serif',
+  fontFamily: 'sans-serif',
   chatMessagePaddingValue: 5,
   chatMessagePaddingUnit: 'px',
   animatedExit: false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,8 @@ export const DEFAULT_CHAT_SETTINGS_VALUES = {
   textStrokeEnabled: false,
   showNameAlias: true,
   animatedEntry: true,
+  // Base64url-encoded UserFilterConfig for username filtering
+  filters: '',
 };
 
 export const chatSearchParamsMap = {
@@ -68,4 +70,5 @@ export const chatSearchParamsMap = {
   fontFamily: 'font-family',
   chatMessagePadding: 'chat-message-padding',
   showNameAlias: 'show-name-alias',
+  filters: 'filters',
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,8 +47,8 @@ export const DEFAULT_CHAT_SETTINGS_VALUES = {
   textStrokeEnabled: false,
   showNameAlias: true,
   animatedEntry: true,
-  // Base64url-encoded UserFilterConfig for username filtering
-  filters: '',
+  usernameFilters: '',
+  messageFilters: '',
 };
 
 export const chatSearchParamsMap = {
@@ -70,5 +70,6 @@ export const chatSearchParamsMap = {
   fontFamily: 'font-family',
   chatMessagePadding: 'chat-message-padding',
   showNameAlias: 'show-name-alias',
-  filters: 'filters',
+  usernameFilters: 'username-filters',
+  messageFilters: 'message-filters',
 };

--- a/src/utils/filters.test.ts
+++ b/src/utils/filters.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { buildUsernameRegex, type UserFilterConfig } from './filters';
+
+describe('buildUsernameRegex - per-rule case sensitivity', () => {
+  it('contains: case-insensitive when caseSensitive=false', () => {
+    const cfg: UserFilterConfig = {
+      rules: [{ matchType: 'contains', pattern: 'foo', caseSensitive: false }],
+    } as const;
+    const re = buildUsernameRegex(cfg)!;
+    expect(re.test('bar')).toBe(true); // not excluded
+    expect(re.test('foobar')).toBe(false); // excluded
+    expect(re.test('FOObar')).toBe(false); // excluded due to per-rule insensitivity
+  });
+
+  it('contains: case-sensitive when caseSensitive=true', () => {
+    const cfg: UserFilterConfig = {
+      rules: [{ matchType: 'contains', pattern: 'foo', caseSensitive: true }],
+    } as const;
+    const re = buildUsernameRegex(cfg)!;
+    expect(re.test('foobar')).toBe(false); // excluded
+    expect(re.test('FOObar')).toBe(true); // not excluded (case mismatch)
+  });
+
+  it('exact: applies sensitivity only to that rule', () => {
+    const cfg: UserFilterConfig = {
+      rules: [{ matchType: 'exact', pattern: 'Alice', caseSensitive: false }],
+    } as const;
+    const re = buildUsernameRegex(cfg)!;
+    expect(re.test('Alice')).toBe(false);
+    expect(re.test('ALICE')).toBe(false); // excluded via per-rule insensitivity
+    expect(re.test('Alice1')).toBe(true); // not exact
+  });
+
+  it('wildcard: respects case-sensitive matching', () => {
+    const cfg: UserFilterConfig = {
+      rules: [{ matchType: 'wildcard', pattern: 'a*e', caseSensitive: true }],
+    } as const;
+    const re = buildUsernameRegex(cfg)!;
+    expect(re.test('axe')).toBe(false); // excluded
+    expect(re.test('Axe')).toBe(true); // case mismatch, allowed
+  });
+
+  it('mixed rules: each rule sensitivity is independent', () => {
+    const cfg: UserFilterConfig = {
+      rules: [
+        { matchType: 'exact', pattern: 'Mod', caseSensitive: true },
+        { matchType: 'contains', pattern: 'bot', caseSensitive: false },
+      ],
+    } as const;
+    const re = buildUsernameRegex(cfg)!;
+    expect(re.test('Mod')).toBe(false); // excluded by exact
+    expect(re.test('MOD')).toBe(true); // exact is sensitive, so allowed
+    expect(re.test('NightBot')).toBe(false); // excluded by contains (insensitive)
+  });
+});

--- a/src/utils/filters.test.ts
+++ b/src/utils/filters.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { buildUsernameRegex, type UserFilterConfig } from './filters';
+import { buildFilterRegex, type UserFilterConfig } from './filters';
 
 describe('buildUsernameRegex - per-rule case sensitivity', () => {
   it('contains: case-insensitive when caseSensitive=false', () => {
     const cfg: UserFilterConfig = {
       rules: [{ matchType: 'contains', pattern: 'foo', caseSensitive: false }],
     } as const;
-    const re = buildUsernameRegex(cfg)!;
+    const re = buildFilterRegex(cfg)!;
     expect(re.test('bar')).toBe(true); // not excluded
     expect(re.test('foobar')).toBe(false); // excluded
     expect(re.test('FOObar')).toBe(false); // excluded due to per-rule insensitivity
@@ -16,7 +16,7 @@ describe('buildUsernameRegex - per-rule case sensitivity', () => {
     const cfg: UserFilterConfig = {
       rules: [{ matchType: 'contains', pattern: 'foo', caseSensitive: true }],
     } as const;
-    const re = buildUsernameRegex(cfg)!;
+    const re = buildFilterRegex(cfg)!;
     expect(re.test('foobar')).toBe(false); // excluded
     expect(re.test('FOObar')).toBe(true); // not excluded (case mismatch)
   });
@@ -25,7 +25,7 @@ describe('buildUsernameRegex - per-rule case sensitivity', () => {
     const cfg: UserFilterConfig = {
       rules: [{ matchType: 'exact', pattern: 'Alice', caseSensitive: false }],
     } as const;
-    const re = buildUsernameRegex(cfg)!;
+    const re = buildFilterRegex(cfg)!;
     expect(re.test('Alice')).toBe(false);
     expect(re.test('ALICE')).toBe(false); // excluded via per-rule insensitivity
     expect(re.test('Alice1')).toBe(true); // not exact
@@ -35,7 +35,7 @@ describe('buildUsernameRegex - per-rule case sensitivity', () => {
     const cfg: UserFilterConfig = {
       rules: [{ matchType: 'wildcard', pattern: 'a*e', caseSensitive: true }],
     } as const;
-    const re = buildUsernameRegex(cfg)!;
+    const re = buildFilterRegex(cfg)!;
     expect(re.test('axe')).toBe(false); // excluded
     expect(re.test('Axe')).toBe(true); // case mismatch, allowed
   });
@@ -47,7 +47,7 @@ describe('buildUsernameRegex - per-rule case sensitivity', () => {
         { matchType: 'contains', pattern: 'bot', caseSensitive: false },
       ],
     } as const;
-    const re = buildUsernameRegex(cfg)!;
+    const re = buildFilterRegex(cfg)!;
     expect(re.test('Mod')).toBe(false); // excluded by exact
     expect(re.test('MOD')).toBe(true); // exact is sensitive, so allowed
     expect(re.test('NightBot')).toBe(false); // excluded by contains (insensitive)

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -63,7 +63,7 @@ function toCaseInsensitive(body: string): string {
 
 // Build final regex from exclude-only rules with per-rule case sensitivity.
 // We construct chained negative lookaheads, one per rule, anchored at ^ ... .*$
-export function buildUsernameRegex(cfg: UserFilterConfig): RegExp | null {
+export function buildFilterRegex(cfg: UserFilterConfig): RegExp | null {
   if (!cfg || !Array.isArray(cfg.rules) || cfg.rules.length === 0) {
     return null;
   }

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,0 +1,151 @@
+// User/message filter utilities: schema, compiler, and URL (de)serialization
+
+export type MatchType = 'exact' | 'contains' | 'wildcard';
+
+export type UserFilterRule = {
+  // Exclude-only rules
+  matchType: MatchType;
+  pattern: string;
+  caseSensitive?: boolean; // default false
+};
+
+export type UserFilterConfig = {
+  rules: UserFilterRule[];
+};
+
+export const EMPTY_FILTER_CONFIG: UserFilterConfig = { rules: [] };
+
+// Escape regex metacharacters
+const reEscape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Convert a single rule into a regex body string
+function ruleToBody(rule: UserFilterRule): string {
+  const raw = rule.pattern ?? '';
+  switch (rule.matchType) {
+    case 'exact':
+      return `^${reEscape(raw)}$`;
+    case 'contains':
+      return `${reEscape(raw)}`;
+    case 'wildcard': {
+      // Convert user wildcard to safe regex:
+      //   * -> .*
+      //   ? -> .
+      let body = raw
+        .split('')
+        .map((ch) => {
+          if (ch === '*') return '__STAR__';
+          if (ch === '?') return '__Q__';
+          return reEscape(ch);
+        })
+        .join('');
+      body = body.split('__STAR__').join('.*').split('__Q__').join('.');
+      return `^${body}$`;
+    }
+    default:
+      return `${reEscape(raw)}`;
+  }
+}
+
+// Transform a pattern to behave case-insensitively without using the global 'i' flag.
+// This keeps case sensitivity configurable per rule by expanding ASCII letters.
+function toCaseInsensitive(body: string): string {
+  return body.replace(/[A-Za-z]/g, (ch) => {
+    const lo = ch.toLowerCase();
+    const up = ch.toUpperCase();
+    // non-alphabetic or non-ASCII
+    if (lo === up) {
+      return ch;
+    }
+    // Use a simple character class for the two cases
+    return `[${lo}${up}]`;
+  });
+}
+
+// Build final regex from exclude-only rules with per-rule case sensitivity.
+// We construct chained negative lookaheads, one per rule, anchored at ^ ... .*$
+export function buildUsernameRegex(cfg: UserFilterConfig): RegExp | null {
+  if (!cfg || !Array.isArray(cfg.rules) || cfg.rules.length === 0) {
+    return null;
+  }
+
+  const lookaheads: string[] = [];
+
+  for (const r of cfg.rules) {
+    if (!r || !r.pattern?.length) {
+      continue;
+    }
+    let body = ruleToBody(r);
+    // Apply per-rule case handling by expanding letters for insensitive rules
+    if (!r.caseSensitive) {
+      body = toCaseInsensitive(body);
+    }
+    // Make 'contains' rules match anywhere within the string
+    if (r.matchType === 'contains') {
+      body = `.*${body}.*`;
+    }
+    lookaheads.push(`(?!${body})`);
+  }
+
+  if (lookaheads.length === 0) {
+    return null;
+  }
+
+  // Chain all negative lookaheads so all rules must not match
+  const body = `^${lookaheads.join('')}.*$`;
+
+  try {
+    return new RegExp(body);
+  } catch {
+    return null;
+  }
+}
+
+// Base64url helpers with browser/Node compatibility
+function toBase64(s: string): string {
+  return btoa(s);
+}
+
+function fromBase64(s: string): string {
+  return atob(s);
+}
+
+export function toBase64Url(s: string): string {
+  return toBase64(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+export function fromBase64Url(s: string): string {
+  let t = s.replace(/-/g, '+').replace(/_/g, '/');
+  while (t.length % 4) {
+    t += '=';
+  }
+  return fromBase64(t);
+}
+
+export function encodeFiltersToUrl(cfg: UserFilterConfig): string {
+  try {
+    const json = JSON.stringify(cfg ?? EMPTY_FILTER_CONFIG);
+    // If empty config, return empty string to avoid cluttering URL
+    if (json === JSON.stringify(EMPTY_FILTER_CONFIG)) {
+      return '';
+    }
+    return toBase64Url(json);
+  } catch {
+    return '';
+  }
+}
+
+export function decodeFiltersFromUrl(b64u: string | null | undefined): UserFilterConfig {
+  if (!b64u) {
+    return EMPTY_FILTER_CONFIG;
+  }
+  try {
+    const json = fromBase64Url(b64u);
+    const parsed = JSON.parse(json) as UserFilterConfig;
+    if (!parsed || !Array.isArray(parsed.rules)) {
+      return EMPTY_FILTER_CONFIG;
+    }
+    return parsed;
+  } catch {
+    return EMPTY_FILTER_CONFIG;
+  }
+}

--- a/src/views/Chat/DisappearingChat.tsx
+++ b/src/views/Chat/DisappearingChat.tsx
@@ -53,6 +53,7 @@ const Message = ({ chatMessage }: MessageProps) => {
 export const DisappearingChat = () => {
   const chatMessageEvents = store((s) => s.chatMessageEvents);
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const chatSearchParams = useChatSearchParams();
 
   const scrollToBottom = () => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -65,9 +66,11 @@ export const DisappearingChat = () => {
   return (
     <div className="chat-disappearing">
       <AnimatePresence>
-        {chatMessageEvents.map((chatMessage) => (
-          <Message key={chatMessage.message_id} chatMessage={chatMessage} />
-        ))}
+        {chatMessageEvents
+          .filter((m) => (chatSearchParams.usernameFilterRegex ? chatSearchParams.usernameFilterRegex.test(m.chatter_user_name) : true))
+          .map((chatMessage) => (
+            <Message key={chatMessage.message_id} chatMessage={chatMessage} />
+          ))}
       </AnimatePresence>
       <div ref={bottomRef} />
     </div>

--- a/src/views/Chat/DisappearingChat.tsx
+++ b/src/views/Chat/DisappearingChat.tsx
@@ -63,14 +63,23 @@ export const DisappearingChat = () => {
     scrollToBottom();
   }, [chatMessageEvents]);
 
+  const filteredMessages = chatMessageEvents.filter((m) => {
+    if (!chatSearchParams.usernameFilterRegex && !chatSearchParams.messageFilterRegex) {
+      return true;
+    }
+
+    const userOk = chatSearchParams.usernameFilterRegex ? chatSearchParams.usernameFilterRegex.test(m.chatter_user_name) : true;
+    const msgOk = chatSearchParams.messageFilterRegex ? chatSearchParams.messageFilterRegex.test(m.message.text) : true;
+
+    return userOk && msgOk;
+  });
+
   return (
     <div className="chat-disappearing">
       <AnimatePresence>
-        {chatMessageEvents
-          .filter((m) => (chatSearchParams.usernameFilterRegex ? chatSearchParams.usernameFilterRegex.test(m.chatter_user_name) : true))
-          .map((chatMessage) => (
-            <Message key={chatMessage.message_id} chatMessage={chatMessage} />
-          ))}
+        {filteredMessages.map((chatMessage) => (
+          <Message key={chatMessage.message_id} chatMessage={chatMessage} />
+        ))}
       </AnimatePresence>
       <div ref={bottomRef} />
     </div>

--- a/src/views/Chat/NonDisappearingChat.tsx
+++ b/src/views/Chat/NonDisappearingChat.tsx
@@ -14,10 +14,14 @@ export const NonDisappearingChat = () => {
   const chatMessages = store((s) => s.chatMessageEvents);
   const virtuoso = useRef<VirtuosoHandle>(null);
 
+  const filteredMessages = chatMessages.filter((m) =>
+    chatSearchParams.usernameFilterRegex ? chatSearchParams.usernameFilterRegex.test(m.chatter_user_name) : true,
+  );
+
   const InnerItem = memo(({ index }: { index: number }) => {
     return (
       <ChatEntry
-        chatMessage={chatMessages[index]}
+        chatMessage={filteredMessages[index]}
         backgroundColor={chatSearchParams.backgroundColor}
         showAvatars={chatSearchParams.showAvatars}
         showBorders={chatSearchParams.showBorders}
@@ -51,8 +55,8 @@ export const NonDisappearingChat = () => {
       alignToBottom={true}
       followOutput={'auto'}
       itemContent={itemContent}
-      totalCount={chatMessages.length}
-      initialTopMostItemIndex={chatMessages.length - 1}
+      totalCount={filteredMessages.length}
+      initialTopMostItemIndex={filteredMessages.length - 1}
       atBottomThreshold={400}
     />
   );

--- a/src/views/Chat/NonDisappearingChat.tsx
+++ b/src/views/Chat/NonDisappearingChat.tsx
@@ -14,9 +14,16 @@ export const NonDisappearingChat = () => {
   const chatMessages = store((s) => s.chatMessageEvents);
   const virtuoso = useRef<VirtuosoHandle>(null);
 
-  const filteredMessages = chatMessages.filter((m) =>
-    chatSearchParams.usernameFilterRegex ? chatSearchParams.usernameFilterRegex.test(m.chatter_user_name) : true,
-  );
+  const filteredMessages = chatMessages.filter((m) => {
+    if (!chatSearchParams.usernameFilterRegex && !chatSearchParams.messageFilterRegex) {
+      return true;
+    }
+
+    const userOk = chatSearchParams.usernameFilterRegex ? chatSearchParams.usernameFilterRegex.test(m.chatter_user_name) : true;
+    const msgOk = chatSearchParams.messageFilterRegex ? chatSearchParams.messageFilterRegex.test(m.message.text) : true;
+
+    return userOk && msgOk;
+  });
 
   const InnerItem = memo(({ index }: { index: number }) => {
     return (

--- a/src/views/Chat/UserBadges.tsx
+++ b/src/views/Chat/UserBadges.tsx
@@ -1,5 +1,6 @@
 import { store } from '../../store/store';
 import { ChannelChatMessageEvent } from '../../types/twitchEvents';
+import { logger } from '../../utils/logger';
 
 interface BadgesProps {
   badges?: ChannelChatMessageEvent['badges'];
@@ -9,7 +10,7 @@ export const UserBadges = ({ badges }: BadgesProps) => {
   const chatBadges = store((s) => s.chatBadges);
 
   if (!badges) {
-    console.warn('No badges provided to UserBadges component.');
+    logger.warn('No badges provided to UserBadges component.');
     return null;
   }
 
@@ -17,7 +18,7 @@ export const UserBadges = ({ badges }: BadgesProps) => {
     const foundBadge = chatBadges[`${badge.set_id}_${badge.id}`];
 
     if (!foundBadge) {
-      console.warn(`Badge not found in store: ${badge.set_id}_${badge.id}`);
+      logger.warn(`Badge not found in store: ${badge.set_id}_${badge.id}`);
       return null;
     }
 

--- a/src/views/Chat/useChatSearchParams.ts
+++ b/src/views/Chat/useChatSearchParams.ts
@@ -1,5 +1,5 @@
 import { chatSearchParamsMap, DEFAULT_CHAT_SETTINGS_VALUES } from '../../constants';
-import { buildUsernameRegex, decodeFiltersFromUrl } from '../../utils/filters';
+import { buildFilterRegex, decodeFiltersFromUrl } from '../../utils/filters';
 
 export const useChatSearchParams = () => {
   const searchParams = new URLSearchParams(window.location.search);
@@ -69,9 +69,14 @@ export const useChatSearchParams = () => {
   const showNameAlias = searchParams.get(chatSearchParamsMap.showNameAlias) === 'false' ? false : DEFAULT_CHAT_SETTINGS_VALUES.showNameAlias;
 
   // Username filter (base64url encoded JSON). Empty means no filtering.
-  const filtersParam = searchParams.get(chatSearchParamsMap.filters) || DEFAULT_CHAT_SETTINGS_VALUES.filters;
+  const filtersParam = searchParams.get(chatSearchParamsMap.usernameFilters) || DEFAULT_CHAT_SETTINGS_VALUES.usernameFilters;
   const _filterCfg = decodeFiltersFromUrl(filtersParam);
-  const usernameFilterRegex = buildUsernameRegex(_filterCfg);
+  const usernameFilterRegex = buildFilterRegex(_filterCfg);
+
+  // Message filter (base64url encoded JSON). Empty means no filtering.
+  const messageFiltersParam = searchParams.get(chatSearchParamsMap.messageFilters) || DEFAULT_CHAT_SETTINGS_VALUES.messageFilters;
+  const _messageFilterCfg = decodeFiltersFromUrl(messageFiltersParam);
+  const messageFilterRegex = buildFilterRegex(_messageFilterCfg);
 
   return {
     animatedEntry,
@@ -93,5 +98,6 @@ export const useChatSearchParams = () => {
     textStrokeSettings,
     width,
     usernameFilterRegex,
+    messageFilterRegex,
   };
 };

--- a/src/views/Chat/useChatSearchParams.ts
+++ b/src/views/Chat/useChatSearchParams.ts
@@ -1,4 +1,5 @@
 import { chatSearchParamsMap, DEFAULT_CHAT_SETTINGS_VALUES } from '../../constants';
+import { buildUsernameRegex, decodeFiltersFromUrl } from '../../utils/filters';
 
 export const useChatSearchParams = () => {
   const searchParams = new URLSearchParams(window.location.search);
@@ -67,6 +68,11 @@ export const useChatSearchParams = () => {
   // Controls whether to show name alias when display name differs from login. Defaults to true.
   const showNameAlias = searchParams.get(chatSearchParamsMap.showNameAlias) === 'false' ? false : DEFAULT_CHAT_SETTINGS_VALUES.showNameAlias;
 
+  // Username filter (base64url encoded JSON). Empty means no filtering.
+  const filtersParam = searchParams.get(chatSearchParamsMap.filters) || DEFAULT_CHAT_SETTINGS_VALUES.filters;
+  const _filterCfg = decodeFiltersFromUrl(filtersParam);
+  const usernameFilterRegex = buildUsernameRegex(_filterCfg);
+
   return {
     animatedEntry,
     animatedExit,
@@ -86,5 +92,6 @@ export const useChatSearchParams = () => {
     textStrokeEnabled,
     textStrokeSettings,
     width,
+    usernameFilterRegex,
   };
 };

--- a/src/views/Main/ChatSettings.less
+++ b/src/views/Main/ChatSettings.less
@@ -16,17 +16,18 @@
     }
   }
 
-  label {
-    width: 100%;
-    display: flex;
-    margin-bottom: 0.5rem;
-    padding: 0;
-  }
-
   &-section {
     padding: 0.5rem;
     border-radius: 5px;
     transition: all 150ms;
+
+    > label {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      padding: 0;
+      margin-bottom: 1rem;
+    }
 
     &:hover {
       border-color: lighten(#433b5d, 10%);
@@ -48,7 +49,6 @@
     border-radius: 6px;
     padding: 8px;
     font-size: 1rem;
-    margin-bottom: 12px;
     outline: none;
 
     &:focus {
@@ -69,7 +69,6 @@
       border-radius: 6px;
       padding: 8px;
       font-size: 1rem;
-      margin-bottom: 12px;
       outline: none;
       transition: border-color 0.2s;
     }
@@ -95,11 +94,14 @@
     }
   }
 
-  &-size-inputs {
+  &-inputs-wrapper {
     display: flex;
     gap: 0.5rem;
-    align-items: baseline;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
 
+  &-size-inputs {
     input {
       flex: 1;
       max-width: 100px;

--- a/src/views/Main/ChatSettings.tsx
+++ b/src/views/Main/ChatSettings.tsx
@@ -54,13 +54,13 @@ export const ChatSettings = ({ chatUrl, setChatUrl }: { chatUrl: string; setChat
   useEffect(() => {
     // Sync encoded filters whenever config changes
     const encoded = encodeFiltersToUrl(userFilterConfig);
-    setOverlayParameters((prev) => ({ ...prev, filters: encoded }));
+    setOverlayParameters((prev) => ({ ...prev, usernameFilters: encoded }));
   }, [userFilterConfig]);
 
   useEffect(() => {
     // Sync encoded filters whenever config changes
     const encoded = encodeFiltersToUrl(messageFilterConfig);
-    setOverlayParameters((prev) => ({ ...prev, filters: encoded }));
+    setOverlayParameters((prev) => ({ ...prev, messageFilters: encoded }));
   }, [messageFilterConfig]);
 
   const handleUpdateUrl = () => {

--- a/src/views/Main/TwitchConnectPage.less
+++ b/src/views/Main/TwitchConnectPage.less
@@ -1,0 +1,57 @@
+.twitch-connect-page {
+  &-info-box {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    background: #232326;
+    margin-bottom: 1rem;
+    justify-content: center;
+  }
+
+  &-logged-out {
+    border-radius: 5px;
+    padding: 1rem;
+    text-align: center;
+    margin-bottom: 1rem;
+  }
+
+  &-url-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-direction: column;
+    padding: 1rem;
+    border: 1px solid #444;
+    border-radius: 6px;
+    margin-top: 1rem;
+    gap: 1rem;
+    background: #1e1e1e;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  &-change-channel {
+    &-wrapper {
+      margin: 1rem 0;
+    }
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  input {
+    &[type='text'],
+    &[type='number'] {
+      border-radius: 3px;
+      background-color: #1a1a1a;
+      color: #ffffff;
+      box-sizing: border-box;
+      color: #f4f4f5;
+      border: 1px solid #444;
+      border-radius: 6px;
+      padding: 8px;
+      font-size: 1rem;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+  }
+}

--- a/src/views/Main/TwitchConnectPage.tsx
+++ b/src/views/Main/TwitchConnectPage.tsx
@@ -46,7 +46,6 @@ export const TwitchConnectPage = () => {
     const generatedStateValue = Math.random().toString(36).substring(2, 15);
     persistedStore.getState().setAuthStateValue(generatedStateValue);
     const authStateValue = persistedStore.getState().authStateValue;
-    console.log('Generated auth state value:', authStateValue);
     window.location.assign(
       `${TWITCH_AUTH_URL}authorize?response_type=token&client_id=${clientId}&redirect_uri=${import.meta.env.VITE_AUTH_REDIRECT_URI}&scope=user%3Aread%3Achat&state=${authStateValue}`,
     );

--- a/src/views/Main/TwitchConnectPage.tsx
+++ b/src/views/Main/TwitchConnectPage.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Button } from '../../components/Button/Button';
+import { useToast } from '../../components/Toast/useToast';
 import { TWITCH_AUTH_URL } from '../../constants';
 import { persistedStore, store } from '../../store/store';
 import { ChatSettings } from './ChatSettings';
+
+import './TwitchConnectPage.less';
 
 const CopyToClipboardButton = ({ text }: { text: string }) => {
   const [success, setSuccess] = useState(false);
@@ -34,6 +37,10 @@ export const TwitchConnectPage = () => {
   const userId = store((s) => s.userId);
   const userLogin = store((s) => s.userLogin);
   const clientId = store((s) => s.clientId);
+  const baseOverlayURL = `${import.meta.env.VITE_BASE_URI}/chat?access_token=${accessToken}`;
+  const [chatUrl, setChatUrl] = useState(baseOverlayURL);
+  const [channelName, setChannelName] = useState('');
+  const toast = useToast();
 
   const handleLogin = () => {
     const generatedStateValue = Math.random().toString(36).substring(2, 15);
@@ -51,12 +58,21 @@ export const TwitchConnectPage = () => {
     window.location.assign('/');
   };
 
-  const [chatUrl, setChatUrl] = useState(`${import.meta.env.VITE_BASE_URI}/chat?access_token=${accessToken}`);
+  const handleChannelNameChange = () => {
+    if (channelName === '') {
+      return;
+    }
+    const url = new URL(chatUrl);
+    url.searchParams.set('channel', channelName);
+    setChatUrl(url.toString());
+
+    toast.showToast('Channel updated!');
+  };
 
   if (accessToken && userLogin && userId) {
     return (
-      <div className="logged-in">
-        <div className="logged-in-info-box">
+      <div className="twitch-connect-page">
+        <div className="twitch-connect-page-info-box">
           <span>
             You are <strong>now connected</strong> to Twitch as{' '}
             <strong>
@@ -76,8 +92,17 @@ export const TwitchConnectPage = () => {
             <li>Create a new browser source</li>
             <li>Paste the following URL into the URL field:</li>
           </ol>
-          <div className="url-container">
+          <div className="twitch-connect-page-url-container">
             <code>{chatUrl}</code> <CopyToClipboardButton text={chatUrl} />
+          </div>
+          <div className="twitch-connect-page-change-channel-wrapper">
+            <p>Optionally set a channel so you can watch someone else's Twitch chat:</p>
+            <div className="twitch-connect-page-change-channel">
+              <input type="text" placeholder="Enter channel name" onChange={(e) => setChannelName(e.target.value)} />
+              <Button type="secondary" onClick={handleChannelNameChange}>
+                Set channel name
+              </Button>
+            </div>
           </div>
         </section>
         <ChatSettings chatUrl={chatUrl} setChatUrl={setChatUrl} />
@@ -86,7 +111,7 @@ export const TwitchConnectPage = () => {
   }
 
   return (
-    <div className="not-logged-in">
+    <div className="twitch-connect-page-logged-out">
       <p>Connect your Twitch account to start using the chat overlay</p>
       <Button type="primary" onClick={handleLogin}>
         Connect with Twitch


### PR DESCRIPTION
With this you can now filter out messages from users matching certain patterns or messages containing certain patterns.

This enables you to for example filter out all messages beginning with `!` (commonly used for Twitch bots) with a wildcard match `!*`

closes #2 